### PR TITLE
Add an Overlap type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,11 @@ type Diff<T extends string, U extends string> = (
 )[T];
 
 /**
+ * Find the overlapping variants between two string unions.
+ */
+type Overlap<T extends string, U extends string> = Diff<T, Diff<T, U>>;
+
+/**
  * Drop keys `K` from `T`.
  *
  * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458


### PR DESCRIPTION
The Overlap type returns a string union whose variants are those that
exist in both of the two argument string unions.

Implements #5.

Best regards!