### PR TITLE
Simplify Overwrite by using new Overlap type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
  * @see https://github.com/pelotom/type-zoo/issues/2
  * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
  */
-export type Overwrite<T, U> = Omit<T, Diff<keyof T, Diff<keyof T, keyof U>>> & U;
+export type Overwrite<T, U> = Omit<T, Overlap<keyof T, keyof U>> & U;
 /**
  * `T` without the possibility of `undefined` or `null`.
  *


### PR DESCRIPTION
The nested usage of Diff in Overwrite is a duplicate of the implementation of the new Overlap type. This change removes that duplication and simplifies the implementation of Overwrite.