### PR TITLE
TypeScript 2.8 — initial support & updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ yarn add type-zoo
 
 ## API
 
-### `Diff<T extends string, U extends string>`
-
-Remove the variants of the second union of string literals from the first.
-
-See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
-
 ---
 
 ### `NoInfer<T>`
@@ -25,6 +19,7 @@ See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
 Use to prevent a usage of type `T` from being inferred in other generics.
 
 Example:
+
 ```ts
 declare function assertEqual<T>(actual: T, expected: NoInfer<T>): boolean;
 ```
@@ -38,19 +33,11 @@ See: https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-322267089
 
 ---
 
-### `NonNullable<T>`
-
-`T` without the possibility of `undefined` or `null`.
-
-See: https://github.com/Microsoft/TypeScript/issues/15012#issuecomment-346499713
-
----
-
 ### `Omit<T, K extends keyof T>`
 
 Drop keys `K` from `T`.
 
-See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
 
 ---
 
-### `Overlap<T extends string, U extends string>`
-
-Find the overlapping variants between two string unions.
-
----
-
 ### `Overwrite<T, U>`
 
 Like `T & U`, but where there are overlapping properties using the type from `U` only.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
 
 Like `T & U`, but where there are overlapping properties using the type from `U` only.
 
-See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+See: https://github.com/pelotom/type-zoo/pull/14#discussion_r183527882
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Tom Crockett",
   "license": "MIT",
   "devDependencies": {
-    "dtslint": "^0.2.0",
+    "dtslint": "^0.3.0",
     "typescript": "^2.8.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "dtslint": "^0.2.0",
-    "typescript": "^2.6.2"
+    "typescript": "^2.8.1"
   },
   "scripts": {
     "test": "dtslint types"

--- a/types/diff.ts
+++ b/types/diff.ts
@@ -1,6 +1,0 @@
-import { Diff } from 'type-zoo';
-
-declare const foo: Diff<'foo' | 'bar' | 'baz', 'bar'>;
-
-// $ExpectType "foo" | "baz"
-foo;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,12 +53,6 @@ export type Overwrite<T, U> = {
 export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 
 /**
- * Deprecated: available in TypeScript Core as of 2.8
- * @see https://github.com/Microsoft/TypeScript-Handbook/blame/master/pages/release%20notes/TypeScript%202.8.md#L203
- */
-export type NonNullable<T> = T & {};
-
-/**
  * Forgets contextual knowledge of partiality of keys.
  */
 export type Purify<T extends string> = { [P in T]: T; }[T];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,11 +31,9 @@ export type Overlap<T extends string, U extends string> = Diff<T, Diff<T, U>>;
  * type from U only.
  *
  * @see https://github.com/pelotom/type-zoo/issues/2
- * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377692897
+ * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
  */
-export type Overwrite<T, U> = {
-  [P in Exclude<keyof T, keyof U>]: T[P]
-} & U;
+export type Overwrite<T, U> = Omit<T, Extract<keyof T, keyof U>> & U;
 
 /**
  * Use to prevent a usage of type `T` from being inferred in other generics.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,10 +11,11 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
  * Like `T & U`, but where there are overlapping properties using the
  * type from U only.
  *
- * @see https://github.com/pelotom/type-zoo/issues/2
- * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+ * @see Old: https://github.com/pelotom/type-zoo/issues/2
+ * @see Old: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+ * @see New: https://github.com/pelotom/type-zoo/pull/14#discussion_r183527882
  */
-export type Overwrite<T, U> = Omit<T, Extract<keyof T, keyof U>> & U;
+export type Overwrite<T, U> = Omit<T, keyof T & keyof U> & U;
 
 /**
  * Use to prevent a usage of type `T` from being inferred in other generics.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,11 +8,7 @@
  *
  * @see https://github.com/Microsoft/TypeScript-Handbook/blame/master/pages/release%20notes/TypeScript%202.8.md#L245
  */
-export type Diff<T extends string, U extends string> = (
-  & { [P in T]: P }
-  & { [P in U]: never }
-  & { [x: string]: never }
-)[T];
+export type Diff<T, K> = Exclude<T, K>;
 
 /**
  * Drop keys `K` from `T`.
@@ -24,7 +20,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /**
  * Find the overlapping variants between two string unions.
  */
-export type Overlap<T extends string, U extends string> = Diff<T, Diff<T, U>>;
+export type Overlap<T extends string, U extends string> = Exclude<T, Exclude<T, U>>;
 
 /**
  * Like `T & U`, but where there are overlapping properties using the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,26 +1,11 @@
 // TypeScript Version: 2.8
 
 /**
- * Remove the variants of the second union of string literals from
- * the first.
- *
- * TypeScript Documentation suggests that as of 2.8 you should use the built-in "Exclude" instead.
- *
- * @see https://github.com/Microsoft/TypeScript-Handbook/blame/master/pages/release%20notes/TypeScript%202.8.md#L245
- */
-export type Diff<T, K> = Exclude<T, K>;
-
-/**
  * Drop keys `K` from `T`.
  *
  * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
  */
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-/**
- * Find the overlapping variants between two string unions.
- */
-export type Overlap<T extends string, U extends string> = Exclude<T, Exclude<T, U>>;
 
 /**
  * Like `T & U`, but where there are overlapping properties using the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,10 +1,12 @@
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /**
  * Remove the variants of the second union of string literals from
  * the first.
  *
- * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+ * TypeScript Documentation suggests that as of 2.8 you should use the built-in "Exclude" instead.
+ *
+ * @see https://github.com/Microsoft/TypeScript-Handbook/blame/master/pages/release%20notes/TypeScript%202.8.md#L245
  */
 export type Diff<T extends string, U extends string> = (
   & { [P in T]: P }
@@ -15,9 +17,9 @@ export type Diff<T extends string, U extends string> = (
 /**
  * Drop keys `K` from `T`.
  *
- * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+ * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
  */
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 /**
  * Find the overlapping variants between two string unions.
@@ -29,9 +31,11 @@ export type Overlap<T extends string, U extends string> = Diff<T, Diff<T, U>>;
  * type from U only.
  *
  * @see https://github.com/pelotom/type-zoo/issues/2
- * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
+ * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377692897
  */
-export type Overwrite<T, U> = Omit<T, Overlap<keyof T, keyof U>> & U;
+export type Overwrite<T, U> = {
+  [P in Exclude<keyof T, keyof U>]: T[P]
+} & U;
 
 /**
  * Use to prevent a usage of type `T` from being inferred in other generics.
@@ -49,9 +53,8 @@ export type Overwrite<T, U> = Omit<T, Overlap<keyof T, keyof U>> & U;
 export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 
 /**
- * `T` without the possibility of `undefined` or `null`.
- *
- * @see https://github.com/Microsoft/TypeScript/issues/15012#issuecomment-346499713
+ * Deprecated: available in TypeScript Core as of 2.8
+ * @see https://github.com/Microsoft/TypeScript-Handbook/blame/master/pages/release%20notes/TypeScript%202.8.md#L203
  */
 export type NonNullable<T> = T & {};
 

--- a/types/non-nullable.ts
+++ b/types/non-nullable.ts
@@ -1,5 +1,0 @@
-import { NonNullable } from 'type-zoo';
-
-declare const foo: NonNullable<number | undefined>;
-
-const n: number = foo;

--- a/types/overlap.ts
+++ b/types/overlap.ts
@@ -1,6 +1,0 @@
-import { Overlap } from 'type-zoo';
-
-declare const foo: Overlap<'foo' | 'bar', 'bar' | 'baz'>;
-
-// $ExpectType "bar"
-foo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,9 +304,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 typescript@next:
   version "2.8.0-dev.20180127"

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,9 +89,9 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-definitelytyped-header-parser@Microsoft/definitelytyped-header-parser#production:
+"definitelytyped-header-parser@github:Microsoft/definitelytyped-header-parser#production":
   version "0.0.0"
-  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/210b44cf9e7e5b9783a41df4f664695ade5325b1"
+  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/f074e863231ef0d79a31c0a9edaf1b82c98469ef"
   dependencies:
     "@types/parsimmon" "^1.3.0"
     parsimmon "^1.2.0"
@@ -100,14 +100,14 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
-dtslint@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.2.0.tgz#7723be0d974ad133ff1e5cdb84728669ca66c51e"
+dtslint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.3.0.tgz#918e664a6f7e1f54ba22088daa2bc6e64a6001c1"
   dependencies:
     definitelytyped-header-parser Microsoft/definitelytyped-header-parser#production
     fs-promise "^2.0.0"
     strip-json-comments "^2.0.1"
-    tslint "^5.4.2"
+    tslint "^5.9.1"
     typescript next
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
@@ -281,7 +281,7 @@ tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslint@^5.4.2:
+tslint@^5.9.1:
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
   dependencies:


### PR DESCRIPTION
A quick stab at importing some of the new best ways to implement these helper functions using TypeScript 2.8 features.

- Removes discouraged `Diff<…>` helper from README and document suggestion of using `Exclude`
- Removes now-public `NonNullable` implementation from README, and document that it's now globally available
- Update implementations of `Omit` and `Overwrite` based on community & MS recommendations

Unfortunately, to test this (today), you have to manually patch `definitelytyped-header-parser` in your node_modules directory, as it doesn't yet support TypeScript 2.8 (via a constant) and because of this dtslint can't test the code. If you do patch that to allow TypeScript 2.8, then the tests pass.

Fixes #13 