### PR TITLE
Specify 'files' attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "scripts": {
     "test": "dtslint types"
-  }
+  },
+  "files": [
+    "types/index.d.ts"
+  ]
 }


### PR DESCRIPTION
This prevents tests and any other artifcats from being included in the published package.
README, LICENSE, and package.json are always included by default