### PR TITLE
Remove Required<T> and unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ See: https://github.com/pelotom/type-zoo/pull/14#discussion_r183527882
 
 ---
 
-### `Required<T>`
-
-The opposite of `Partial`. Make all properties of `T` required and non-nullable.
-
-See: https://github.com/Microsoft/TypeScript/issues/15012#issuecomment-346499713
-
----
-
 ### `unknown`
 
 A more principled `any`. Anything can be assigned to `unknown` but nothing can be done with an `unknown` value without further inspection (type guards/predicates). The same idea as [Flow's `mixed` type](https://flow.org/en/docs/types/mixed/).

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,15 +38,6 @@ export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 export type Purify<T extends string> = { [P in T]: T; }[T];
 
 /**
- * Make all properties of `T` required and non-nullable.
- *
- * @see https://github.com/Microsoft/TypeScript/issues/15012#issuecomment-346499713
- */
-export type Required<T> = {
-  [P in Purify<keyof T>]: NonNullable<T[P]>;
-};
-
-/**
  * The type of all values; nothing is known about it a priori
  * except that it exists. The same idea as Flow's `mixed` type.
  *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,14 +38,6 @@ export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 export type Purify<T extends string> = { [P in T]: T; }[T];
 
 /**
- * The type of all values; nothing is known about it a priori
- * except that it exists. The same idea as Flow's `mixed` type.
- *
- * @see https://github.com/Microsoft/TypeScript/issues/10715
- */
-export type unknown = {} | undefined | null;
-
-/**
  * Picks 2 levels deep into a nested object!
  *
  * @see https://gist.github.com/staltz/368866ea6b8a167fbdac58cddf79c1bf

--- a/types/required.ts
+++ b/types/required.ts
@@ -1,6 +1,0 @@
-import { Required } from 'type-zoo';
-
-declare const foo: Required<{ x: number, y?: boolean }>;
-
-const n: number = foo.x;
-const b: boolean = foo.y;


### PR DESCRIPTION
It's included in the default lib since TypeScript 2.8

Fixes https://github.com/pelotom/type-zoo/issues/18

Unfortunately the tests for typescript@next don't work because `unknown` will become a reserved type name in TS 3.0. Not really related to the Required changes and something people on earlier versions of TS could still use, so I'm not removing it as part of this PR.