### PR TITLE
Func args

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "dtslint": "^0.3.0",
     "prettier": "^1.13.7",
-    "typescript": "^2.8.1"
+    "typescript": "^3.0.1"
   },
   "scripts": {
     "format": "prettier $([ \"$CI\" == true ] && echo --list-different || echo --write) './**/*.{ts,tsx,js,json,css}'",

--- a/types/func-args.ts
+++ b/types/func-args.ts
@@ -1,0 +1,53 @@
+// TODO uncomment these tests after https://github.com/Microsoft/definitelytyped-header-parser/pull/15
+// will be deployed.
+// // $ExpectType string
+type S = string;
+// import { FuncArgs } from 'type-zoo';
+
+// function a() {
+//   return;
+// }
+// const b = () => {
+//   return;
+// };
+
+// // $ExpectType []
+// type A1 = FuncArgs<typeof a>;
+// // $ExpectType []
+// type B1 = FuncArgs<typeof b>;
+
+// const c1 = (a: string) => {
+//   return;
+// };
+// const c2 = (a: number, b: boolean) => {
+//   return;
+// };
+// function c3(a: boolean[], b: object, c: any, d: 'foo') {
+//   return;
+// }
+// function c4(a: number, ...args: string[]) {
+//   return;
+// }
+// function c5(a: boolean[], b: object, c: any, d: 'foo', e: 1, ...args: any[]) {
+//   return;
+// }
+
+// // $ExpectType [string]
+// type C1 = FuncArgs<typeof c1>;
+// // $ExpectType [number, boolean]
+// type C2 = FuncArgs<typeof c2>;
+// // $ExpectType [boolean[], object, any, "foo"]
+// type C3 = FuncArgs<typeof c3>;
+
+// // Var-args -- rest parameters!
+// // $ExpectType [number, ...string[]]
+// type C4 = FuncArgs<typeof c4>;
+
+// // No limitations for args count
+// // $ExpectType [boolean[], object, any, "foo", 1, ...any[]]
+// type C5 = FuncArgs<typeof c5>;
+
+// interface D {}
+
+// // $ExpectError
+// type D1 = FuncArgs<D>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
+// TODO change verion to 3.0 to make FuncArgs work properly
 // TypeScript Version: 2.8
-
 /**
  * Drop keys `K` from `T`.
  *
@@ -72,9 +72,13 @@ export type ParamTypes<F extends Function> = F extends () => any // tslint:disab
       : F extends (p0: infer P0, p1: infer P1, p2: infer P2) => any
         ? [P0, P1, P2]
         : F extends (p0: infer P0, p1: infer P1, p2: infer P2, p3: infer P3) => any
-          ? [P0, P1, P2, P3]
-          : // ... -- extend this at your own risk, this could be bad for compilation performance!
-            never;
+          ? [P0, P1, P2, P3] // ... -- extend this at your own risk, this could be bad for compilation performance!
+          : never;
+/**
+ * Selects all arguments from a provided function type.
+ * To get specific argument use index: FuncArgs<(a: number, b: string) => void>[1] // string
+ */
+export type FuncArgs<F extends Function> = F extends (...args: infer Args) => any ? Args : never;
 
 /**
  * Picks 2 levels deep into a nested object!

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,9 +308,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^2.8.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 typescript@next:
   version "3.0.0-dev.20180710"


### PR DESCRIPTION
This PR uses Tuples from TS v3 which allows to extract function args much easier.
Currently it doesn't work as dtslint package should add TS v3 into their repository to make tests pass.