### PR TITLE
Add OmitStrict type for when you don't want to be permissive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
 
 ---
 
+### `OmitStrict<T, K extends keyof T>`
+
+Drop keys `K` from `T`, where `K` must exist in `T`.
+
+See: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
+
+---
+
 ### `Overwrite<T, U>`
 
 Like `T & U`, but where there are overlapping properties using the type from `U` only.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,18 @@
 // TypeScript Version: 2.8
 
 /**
- * Drop keys `K` from `T`.
+ * Drop keys `K` from `T` if they are present.
  *
  * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
  */
 export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+
+/**
+ * Drop keys `K` from `T`, where `K` must exist in `T`.
+ *
+ * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
+ */
+export type OmitStrict<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
 /**
  * Like `T & U`, but where there are overlapping properties using the

--- a/types/omit.ts
+++ b/types/omit.ts
@@ -1,9 +1,28 @@
-import { Omit } from 'type-zoo';
+import { Omit, OmitStrict } from 'type-zoo';
 
-declare const foo: Omit<{ x: boolean; y: string }, 'x'>;
+declare const omitExistingField: Omit<{ x: boolean; y: string }, 'x'>;
 
 // $ExpectType string
-foo.y;
+omitExistingField.y;
 
 // $ExpectError
-foo.x;
+omitExistingField.x;
+
+declare const omitNonexistentField: Omit<{ x: boolean }, 'y'>;
+
+// $ExpectType boolean
+omitNonexistentField.x;
+
+// $ExpectError
+omitNonexistentField.y;
+
+// $ExpectError
+declare const omitNonexistentFieldStrict: OmitStrict<{ x: boolean }, 'y'>;
+
+declare const omitExistingFieldStrict: OmitStrict<{ x: boolean; y: string }, 'x'>;
+
+// $ExpectType string
+omitExistingField.y;
+
+// $ExpectError
+omitExistingField.x;


### PR DESCRIPTION
I preferred the old behavior of `Omit` before it was made permissive, but I understand the use-cases for it. This PR re-introduces the original behavior under a different name.

The benefit that a stricter type has is primarily:

- Preventing typos.
- Allowing the compiler to pick up on rename refactors automatically.

Currently, permissive `Omit` acts as a "barrier" that prevents rename refactors from passing through, which means that any such refactor generates whole bunches of errors that have to be manually fixed. If the field in question is optional, this can actually introduce bugs.

I'm open to bike-shedding the name, but I'd like to have both types available so I don't have to pin to an old version of the library or re-declare my own strict variants!