### PR TITLE
Add Public<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Like `Pick<>` but for `#` of nested levels!
 
 See https://gist.github.com/staltz/368866ea6b8a167fbdac58cddf79c1bf
 
+---
+
+### `Public#<T>`
+
+Get only the public members of a type or class. When applied to a class T with private members, Public<T> can be implemented.
+
+See https://github.com/Microsoft/TypeScript/issues/18499#issuecomment-429272545
 
 ## Related Projects
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,26 @@ export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 export type Purify<T extends string> = { [P in T]: T }[T];
 
 /**
+ * Get the public interface of a type. This is useful for working with classes that have private members.
+ *
+ * export class Foo {
+ *   private priv: string;
+ *
+ *   bar(): number {
+ *     // ...
+ *   }
+ * }
+ *
+ * export type IFoo = Public<Foo>;
+ *
+ * // Can mock or fake
+ * const fakeFoo: IFoo = {
+ *   bar(): { return 1;}
+ * }
+ */
+export type Public<T> = { [P in keyof T]: T[P] };
+
+/**
  * Selects the type of the 0th parameter in a function-type
  */
 export type Param0<Func> = Func extends (a: infer T, ...args: any[]) => any ? T : never;

--- a/types/public.ts
+++ b/types/public.ts
@@ -1,0 +1,17 @@
+import { Public } from 'type-zoo';
+
+class Foo {
+    private readonly n = 1;
+
+    bar(): string {
+        return 'abc';
+    }
+}
+
+type IFoo = Public<Foo>;
+
+const m: IFoo = {
+    bar(): string {
+        return 'def';
+    }
+};


### PR DESCRIPTION
Problem: a class with private members cannot be mocked without bypassing the typechecker.

Solution: Add a type `Public<T>` that maps only the public members. This makes it easy to get a class's public interface for dependency injection and mocking.

```
type Public<T> = { [P in keyof T]: T[P] };

export class Foo {
    private _priv = 1;

    public getStr():string {
        return 'abc';
    }
}

// Type '{ getStr(): string; }' is not assignable to type 'Foo'.
//  Property '_priv' is missing in type '{ getStr(): string; }'.
const naiveFake: Foo = {
    getStr(): string {
        return 'def';
    }
}

export type IFoo = Public<Foo>;

// Works!
const fake: IFoo = {
    getStr(): string {
        return 'def';
    }
}
```

See this comment:
https://github.com/Microsoft/TypeScript/issues/18499#issuecomment-429272545