### PR TITLE
Add the main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "type-zoo",
   "version": "3.4.0",
   "description": "A menagerie of useful type operators for TypeScript",
+  "main": "types/index.d.ts",
   "types": "types",
   "repository": "https://github.com/pelotom/type-zoo",
   "author": "Tom Crockett",


### PR DESCRIPTION
This change adds the [`main`](https://docs.npmjs.com/files/package.json#main) field to `package.json` which facilitates module resolution in various circumstances.

#### ESLint Example

```ts
import { Overwrite } from 'type-zoo';

// error: Unable to resolve path to module 'type-zoo'  import/no-unresolved
```

After adding the `main` field, this works as expected.